### PR TITLE
Add product detail pages with CTA links

### DIFF
--- a/corpo-mais-firme.html
+++ b/corpo-mais-firme.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Corpo Mais Firme com 15 Min/Dia</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap');
+        body {
+            font-family: 'Montserrat', sans-serif;
+            color: #5a5a5a;
+        }
+        .title-font {
+            font-family: 'Playfair Display', serif;
+        }
+    </style>
+</head>
+<body class="bg-white">
+    <section class="container mx-auto px-4 py-12 md:py-24">
+        <h1 class="title-font text-4xl md:text-5xl font-bold text-gray-800 mb-6">Corpo Mais Firme com 15 Min/Dia</h1>
+        <p class="text-lg text-gray-600 mb-6">
+            Treinos rápidos para glúteos, barriga e postura sem precisar de academia ou equipamentos caros.
+        </p>
+        <ul class="list-disc list-inside text-gray-600 mb-8 space-y-2">
+            <li>Sessões guiadas de apenas 15 minutos.</li>
+            <li>Vídeos demonstrativos e calendário semanal.</li>
+            <li>Acompanhamento para evolução dos resultados.</li>
+        </ul>
+        <a href="#" class="bg-blue-500 hover:bg-blue-600 text-white font-medium py-3 px-6 rounded-full shadow-md">
+            Quero comprar agora
+        </a>
+    </section>
+</body>
+</html>

--- a/desincha-express.html
+++ b/desincha-express.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Desincha Express</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap');
+        body {
+            font-family: 'Montserrat', sans-serif;
+            color: #5a5a5a;
+        }
+        .title-font {
+            font-family: 'Playfair Display', serif;
+        }
+    </style>
+</head>
+<body class="bg-white">
+    <section class="container mx-auto px-4 py-12 md:py-24">
+        <h1 class="title-font text-4xl md:text-5xl font-bold text-gray-800 mb-6">Desincha Express</h1>
+        <p class="text-lg text-gray-600 mb-6">
+            Plano de 5 dias de alimentação desinflamatória para eliminar o inchaço e recuperar sua leveza.
+        </p>
+        <ul class="list-disc list-inside text-gray-600 mb-8 space-y-2">
+            <li>Cardápios simples e saborosos.</li>
+            <li>Dicas para manter o foco e a energia.</li>
+            <li>Lista de compras prática para toda a semana.</li>
+        </ul>
+        <a href="#" class="bg-green-500 hover:bg-green-600 text-white font-medium py-3 px-6 rounded-full shadow-md">
+            Quero comprar agora
+        </a>
+    </section>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -151,9 +151,9 @@
                         </p>
                         <div class="flex justify-between items-center">
                             <span class="font-bold text-pink-500 text-xl">R$ 37</span>
-                            <button class="text-pink-500 hover:text-pink-600 font-medium transition">
+                            <a href="sua-pele-mais-leve.html" class="text-pink-500 hover:text-pink-600 font-medium transition">
                                 Saiba mais <i class="fas fa-arrow-right ml-1"></i>
-                            </button>
+                            </a>
                         </div>
                     </div>
                 </div>
@@ -170,9 +170,9 @@
                         </p>
                         <div class="flex justify-between items-center">
                             <span class="font-bold text-green-500 text-xl">R$ 27</span>
-                            <button class="text-green-500 hover:text-green-600 font-medium transition">
+                            <a href="desincha-express.html" class="text-green-500 hover:text-green-600 font-medium transition">
                                 Saiba mais <i class="fas fa-arrow-right ml-1"></i>
-                            </button>
+                            </a>
                         </div>
                     </div>
                 </div>
@@ -189,9 +189,9 @@
                         </p>
                         <div class="flex justify-between items-center">
                             <span class="font-bold text-blue-500 text-xl">R$ 47</span>
-                            <button class="text-blue-500 hover:text-blue-600 font-medium transition">
+                            <a href="corpo-mais-firme.html" class="text-blue-500 hover:text-blue-600 font-medium transition">
                                 Saiba mais <i class="fas fa-arrow-right ml-1"></i>
-                            </button>
+                            </a>
                         </div>
                     </div>
                 </div>

--- a/sua-pele-mais-leve.html
+++ b/sua-pele-mais-leve.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sua Pele Mais Leve em 7 Dias</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap');
+        body {
+            font-family: 'Montserrat', sans-serif;
+            color: #5a5a5a;
+        }
+        .title-font {
+            font-family: 'Playfair Display', serif;
+        }
+    </style>
+</head>
+<body class="bg-white">
+    <section class="container mx-auto px-4 py-12 md:py-24">
+        <h1 class="title-font text-4xl md:text-5xl font-bold text-gray-800 mb-6">Sua Pele Mais Leve em 7 Dias</h1>
+        <p class="text-lg text-gray-600 mb-6">
+            Um programa de SkinDetox com passos simples para reduzir a oleosidade, diminuir espinhas e recuperar sua autoestima.
+        </p>
+        <ul class="list-disc list-inside text-gray-600 mb-8 space-y-2">
+            <li>Rotina diária de apenas 10 minutos.</li>
+            <li>Receitas caseiras para cuidar da pele.</li>
+            <li>Dicas de alimentação que potencializam os resultados.</li>
+        </ul>
+        <a href="#" class="bg-pink-500 hover:bg-pink-600 text-white font-medium py-3 px-6 rounded-full shadow-md">
+            Quero comprar agora
+        </a>
+    </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- link "Saiba mais" buttons to new product detail pages
- add detail pages for each product including CTA purchase button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68920ce966a4833292f8439766d85f6c